### PR TITLE
Update lib & Crashlytics support

### DIFF
--- a/Kesshou-Android.iml
+++ b/Kesshou-Android.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="Kesshou-Android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="Kesshou-Android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -108,50 +108,59 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: com.squareup.retrofit2:converter-gson:2.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-basement-10.0.1" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-10.0.1" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-fragment-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.13.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: me.grantland:autofittextview-0.2.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-core-16.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-measurement-base-16.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-basement-15.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-messaging-17.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.7@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-common-10.0.1" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7-25.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.zzhoujay.markdown:markdown-1.0.2" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-compat-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: se.emilsjolander:stickylistheaders-2.5.2" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-1.0.0-beta4" level="project" />
     <orderEntry type="library" name="Gradle: com.squareup.retrofit2:retrofit:2.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: io.reactivex:rxjava:1.0.16@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:25.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-impl-10.0.1" level="project" />
-    <orderEntry type="library" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.0.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-messaging-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat-26.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:26.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-v4-26.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.github.tibolte:agendacalendarview-1.0.4" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:transition-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-iid-10.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-v4-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-crash-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui-26.1.0" level="project" />
     <orderEntry type="library" name="Gradle: io.realm:realm-android-library-object-server-5.4.0" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:recyclerview-v7-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.9.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-tasks-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils-26.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:customtabs-25.1.0" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-solver:1.0.0-beta4@jar" level="project" />
     <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.zzhoujay.richtext:richtext-2.3.7" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-16.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:design-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-tasks-15.0.1" level="project" />
     <orderEntry type="library" name="Gradle: io.realm:realm-annotations:5.4.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-core-10.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.github.bumptech.glide:okhttp3-integration-1.4.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-impl-16.1.1" level="project" />
     <orderEntry type="library" name="Gradle: com.zzhoujay.glideimagegetter:glideimagegetter-1.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.github.bumptech.glide:glide:3.7.0@jar" level="project" />
     <orderEntry type="library" name="Gradle: com.getkeepsafe.relinker:relinker-1.2.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.retrofit2:converter-gson:2.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.13.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: me.grantland:autofittextview-0.2.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: se.emilsjolander:stickylistheaders-2.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-fragment-26.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:common:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-base-15.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: io.reactivex:rxjava:1.0.16@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-compat-26.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-ads-identifier-15.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:transition-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-measurement-connector-impl-16.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.9.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-stats-15.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-solver:1.0.0-beta4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-iid-16.2.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-iid-interop-16.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.zzhoujay.richtext:richtext-2.3.7" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-measurement-connector-16.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-common-16.0.0" level="project" />
     <orderEntry type="library" name="Gradle: com.squareup.okhttp3:logging-interceptor:3.4.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime-1.0.0" level="project" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -32,6 +32,7 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/fabric/res/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/google-services/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
@@ -111,6 +112,7 @@
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-core-16.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-measurement-base-16.0.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-basement-15.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.crashlytics.sdk.android:crashlytics-core-2.6.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-messaging-17.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.7@jar" level="project" />
     <orderEntry type="library" name="Gradle: com.zzhoujay.markdown:markdown-1.0.2" level="project" />
@@ -128,6 +130,8 @@
     <orderEntry type="library" name="Gradle: com.android.support:support-core-utils-26.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:customtabs-25.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.crashlytics.sdk.android:beta-1.2.8" level="project" />
+    <orderEntry type="library" name="Gradle: io.fabric.sdk.android:fabric-1.4.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-16.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:design-25.1.0" level="project" />
     <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-tasks-15.0.1" level="project" />
@@ -159,8 +163,10 @@
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-iid-interop-16.0.0" level="project" />
     <orderEntry type="library" name="Gradle: com.zzhoujay.richtext:richtext-2.3.7" level="project" />
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-measurement-connector-16.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.crashlytics.sdk.android:crashlytics-2.9.3" level="project" />
     <orderEntry type="library" name="Gradle: com.google.firebase:firebase-common-16.0.0" level="project" />
     <orderEntry type="library" name="Gradle: com.squareup.okhttp3:logging-interceptor:3.4.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.crashlytics.sdk.android:answers-1.4.2" level="project" />
     <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime-1.0.0" level="project" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="Kesshou-Android" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,7 +9,6 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <afterSyncTasks>
@@ -23,7 +22,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
@@ -43,20 +42,26 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
@@ -64,78 +69,38 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support.constraint/constraint-layout/1.0.0-beta4/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/customtabs/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-compat/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-ui/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-utils/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-fragment/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-media-compat/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/transition/25.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.getkeepsafe.relinker/relinker/1.2.2/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.github.bumptech.glide/okhttp3-integration/1.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.github.tibolte/agendacalendarview/1.0.4/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-basement/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-tasks/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-analytics-impl/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-analytics/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-common/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-core/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-crash/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-iid/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-messaging/10.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.zzhoujay.glideimagegetter/glideimagegetter/1.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.zzhoujay.markdown/markdown/1.0.2/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.zzhoujay.richtext/richtext/2.3.7/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.realm/realm-android-library/2.1.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/me.grantland/autofittextview/0.2.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/se.emilsjolander/stickylistheaders/2.5.2/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard-rules" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/splits-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
@@ -143,49 +108,50 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="firebase-analytics-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="constraint-layout-1.0.0-beta4" level="project" />
-    <orderEntry type="library" exported="" name="design-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="okhttp3-integration-1.4.0" level="project" />
-    <orderEntry type="library" exported="" name="firebase-core-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="relinker-1.2.2" level="project" />
-    <orderEntry type="library" exported="" name="play-services-tasks-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="constraint-layout-solver-1.0.0-beta4" level="project" />
-    <orderEntry type="library" exported="" name="autofittextview-0.2.1" level="project" />
-    <orderEntry type="library" exported="" name="transition-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="support-fragment-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="glideimagegetter-1.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-ui-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="markdown-1.0.2" level="project" />
-    <orderEntry type="library" exported="" name="richtext-2.3.7" level="project" />
-    <orderEntry type="library" exported="" name="glide-3.7.0" level="project" />
-    <orderEntry type="library" exported="" name="firebase-crash-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="firebase-iid-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-utils-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="customtabs-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="realm-android-library-2.1.1" level="project" />
-    <orderEntry type="library" exported="" name="MPAndroidChart-v3.0.0" level="project" />
-    <orderEntry type="library" exported="" name="stickylistheaders-2.5.2" level="project" />
-    <orderEntry type="library" exported="" name="firebase-analytics-impl-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="retrofit-2.1.0" level="project" />
-    <orderEntry type="library" exported="" name="gson-2.7" level="project" />
-    <orderEntry type="library" exported="" name="converter-gson-2.1.0" level="project" />
-    <orderEntry type="library" exported="" name="firebase-common-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="okio-1.11.0" level="project" />
-    <orderEntry type="library" exported="" name="firebase-messaging-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-compat-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="animated-vector-drawable-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="play-services-basement-10.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="rxjava-1.0.16" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-3.5.0" level="project" />
-    <orderEntry type="library" exported="" name="logging-interceptor-3.4.1" level="project" />
-    <orderEntry type="library" exported="" name="agendacalendarview-1.0.4" level="project" />
-    <orderEntry type="library" exported="" name="support-media-compat-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="support-vector-drawable-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="realm-annotations-2.1.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-25.1.0" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.retrofit2:converter-gson:2.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-basement-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-fragment-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.13.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: me.grantland:autofittextview-0.2.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.7@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-common-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.zzhoujay.markdown:markdown-1.0.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-compat-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: se.emilsjolander:stickylistheaders-2.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-1.0.0-beta4" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.retrofit2:retrofit:2.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: io.reactivex:rxjava:1.0.16@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:25.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-analytics-impl-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.PhilJay:MPAndroidChart:v3.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-messaging-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.tibolte:agendacalendarview-1.0.4" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:transition-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-iid-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-v4-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-crash-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: io.realm:realm-android-library-object-server-5.4.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:recyclerview-v7-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.9.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.gms:play-services-tasks-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:customtabs-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-solver:1.0.0-beta4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.code.findbugs:jsr305:3.0.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.zzhoujay.richtext:richtext-2.3.7" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:design-25.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: io.realm:realm-annotations:5.4.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.firebase:firebase-core-10.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:okhttp3-integration-1.4.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.zzhoujay.glideimagegetter:glideimagegetter-1.0.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.github.bumptech.glide:glide:3.7.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.getkeepsafe.relinker:relinker-1.2.2" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:logging-interceptor:3.4.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils-25.1.0" level="project" />
   </component>
 </module>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,9 @@ dependencies {
     implementation 'me.grantland:autofittextview:0.2.1'
     implementation 'com.zzhoujay.richtext:richtext:2.3.7'
     implementation 'com.zzhoujay.glideimagegetter:glideimagegetter:1.0.1'
-    implementation 'com.google.firebase:firebase-core:10.0.1'
-    implementation 'com.google.firebase:firebase-crash:10.0.1'
-    implementation 'com.google.firebase:firebase-messaging:10.0.1'
+    implementation 'com.google.firebase:firebase-core:16.0.1'
+    implementation 'com.google.firebase:firebase-messaging:17.1.0'
 }
 
-//compile 'com.android.support:multidex:1.0.1'
-
-
 apply plugin: 'com.google.gms.google-services'
+//compile 'com.android.support:multidex:1.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
-
 
     defaultConfig {
         applicationId "kesshou.android.daanx"
@@ -12,6 +10,7 @@ android {
         targetSdkVersion 25
         versionCode 4
         versionName "1.0.6"
+        vectorDrawables.useSupportLibrary = true
         vectorDrawables.generatedDensities = ['hdpi']
     }
     buildTypes {
@@ -22,43 +21,39 @@ android {
         }
     }
 
+}
 
+realm{
+    syncEnabled = true
 }
 
 buildscript {
 
     ext.support_version = '25.1.0'
-
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-
-    compile "com.android.support:support-v4:$support_version"
-    compile "com.android.support:appcompat-v7:$support_version"
-    compile "com.android.support:design:$support_version"
-    compile "com.android.support:recyclerview-v7:$support_version"
-    compile "com.android.support:customtabs:$support_version"
-
-
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.4.1'
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.github.bumptech.glide:okhttp3-integration:1.4.0@aar'
-    compile 'com.github.PhilJay:MPAndroidChart:v3.0.0'
-    compile 'com.github.tibolte:agendacalendarview:1.0.4'
-    compile 'me.grantland:autofittextview:0.2.1'
-    compile 'com.zzhoujay.richtext:richtext:2.3.7'
-    compile 'com.zzhoujay.glideimagegetter:glideimagegetter:1.0.1'
-
-    compile 'com.google.firebase:firebase-core:10.0.1'
-    compile 'com.google.firebase:firebase-crash:10.0.1'
-    compile 'com.google.firebase:firebase-messaging:10.0.1'
-
-
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:support-v4:$support_version"
+    implementation "com.android.support:appcompat-v7:$support_version"
+    implementation "com.android.support:design:$support_version"
+    implementation "com.android.support:recyclerview-v7:$support_version"
+    implementation "com.android.support:customtabs:$support_version"
+    implementation 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    implementation 'com.squareup.retrofit2:retrofit:2.1.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.1.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.4.1'
+    implementation 'com.google.code.gson:gson:2.7'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.github.bumptech.glide:okhttp3-integration:1.4.0@aar'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.0.0'
+    implementation 'com.github.tibolte:agendacalendarview:1.0.4'
+    implementation 'me.grantland:autofittextview:0.2.1'
+    implementation 'com.zzhoujay.richtext:richtext:2.3.7'
+    implementation 'com.zzhoujay.glideimagegetter:glideimagegetter:1.0.1'
+    implementation 'com.google.firebase:firebase-core:10.0.1'
+    implementation 'com.google.firebase:firebase-crash:10.0.1'
+    implementation 'com.google.firebase:firebase-messaging:10.0.1'
 }
 
 //compile 'com.android.support:multidex:1.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 25
@@ -53,6 +54,7 @@ dependencies {
     implementation 'com.zzhoujay.glideimagegetter:glideimagegetter:1.0.1'
     implementation 'com.google.firebase:firebase-core:16.0.1'
     implementation 'com.google.firebase:firebase-messaging:17.1.0'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.3'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/kesshou/android/daanx/service/MyFirebaseInstanceIDService.java
+++ b/app/src/main/java/kesshou/android/daanx/service/MyFirebaseInstanceIDService.java
@@ -22,64 +22,71 @@ import retrofit2.Response;
  * Created by yoyoIU on 2016/12/19.
  */
 
-public class MyFirebaseInstanceIDService extends FirebaseInstanceIdService {
+/*
+I believe Google deprecated this .
+Token updates are now handled in the messaging service
+2018/07/23 JellyKuo
+ */
+// TODO: Review and remove when applicable
 
-	private static final String TAG = "MyFirebaseIIDService";
-
-	/**
-	 * Called if InstanceID token is updated. This may occur if the security of
-	 * the previous token had been compromised. Note that this is called when the InstanceID token
-	 * is initially generated so this is where you would retrieve the token.
-	 */
-	// [START refresh_token]
-	@Override
-	public void onTokenRefresh() {
-		// Get updated InstanceID token.
-		String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-		Log.d(TAG, "Refreshed token: " + refreshedToken);
-
-		// If you want to send messages to this application instance or
-		// manage this apps subscriptions on the server side, send the
-		// Instance ID token to your app server.
-		saveRegistration(refreshedToken);
-		ifSendServerOrNot(refreshedToken);
-	}
-	// [END refresh_token]
-
-	private void saveRegistration(String token){
-		Realm realm = Realm.getDefaultInstance();
-		if(realm.where(NotiSetting.class).findAll().size()==0){
-			realm.beginTransaction();
-			NotiSetting notiSetting = realm.createObject(NotiSetting.class);
-			notiSetting.fcm_token = token;
-			notiSetting.is_noti = true;
-			realm.commitTransaction();
-		}else{
-			NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
-			realm.beginTransaction();
-			notiSetting.fcm_token = token;
-			realm.commitTransaction();
-		}
-		realm.close();
-	}
-
-	private void ifSendServerOrNot(String token){
-		Realm realm = Realm.getDefaultInstance();
-		RealmResults<Setting> settings = realm.where(Setting.class).findAll();
-		if(settings.size()!=0&&settings.get(0).logined){
-			NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
-			new NetworkingClient(getApplicationContext()).setNoti(token, notiSetting.is_noti, new MyCallBack<StatusResponse>(getApplicationContext()) {
-				@Override
-				public void onSuccess(Response<StatusResponse> response) {
-					Log.d("fcm_token",response.body().status);
-				}
-
-				@Override
-				public void onErr(Error error, Call<StatusResponse> call) {
-					call.clone().enqueue(this);
-				}
-			});
-		}
-		realm.close();
-	}
-}
+//public class MyFirebaseInstanceIDService extends FirebaseInstanceIdService {
+//
+//	private static final String TAG = "MyFirebaseIIDService";
+//
+//	/**
+//	 * Called if InstanceID token is updated. This may occur if the security of
+//	 * the previous token had been compromised. Note that this is called when the InstanceID token
+//	 * is initially generated so this is where you would retrieve the token.
+//	 */
+//	// [START refresh_token]
+//	@Override
+//	public void onTokenRefresh() {
+//		// Get updated InstanceID token.
+//		String refreshedToken = FirebaseInstanceId.getInstance().getToken();
+//		Log.d(TAG, "Refreshed token: " + refreshedToken);
+//
+//		// If you want to send messages to this application instance or
+//		// manage this apps subscriptions on the server side, send the
+//		// Instance ID token to your app server.
+//		saveRegistration(refreshedToken);
+//		ifSendServerOrNot(refreshedToken);
+//	}
+//	// [END refresh_token]
+//
+//	private void saveRegistration(String token){
+//		Realm realm = Realm.getDefaultInstance();
+//		if(realm.where(NotiSetting.class).findAll().size()==0){
+//			realm.beginTransaction();
+//			NotiSetting notiSetting = realm.createObject(NotiSetting.class);
+//			notiSetting.fcm_token = token;
+//			notiSetting.is_noti = true;
+//			realm.commitTransaction();
+//		}else{
+//			NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
+//			realm.beginTransaction();
+//			notiSetting.fcm_token = token;
+//			realm.commitTransaction();
+//		}
+//		realm.close();
+//	}
+//
+//	private void ifSendServerOrNot(String token){
+//		Realm realm = Realm.getDefaultInstance();
+//		RealmResults<Setting> settings = realm.where(Setting.class).findAll();
+//		if(settings.size()!=0&&settings.get(0).logined){
+//			NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
+//			new NetworkingClient(getApplicationContext()).setNoti(token, notiSetting.is_noti, new MyCallBack<StatusResponse>(getApplicationContext()) {
+//				@Override
+//				public void onSuccess(Response<StatusResponse> response) {
+//					Log.d("fcm_token",response.body().status);
+//				}
+//
+//				@Override
+//				public void onErr(Error error, Call<StatusResponse> call) {
+//					call.clone().enqueue(this);
+//				}
+//			});
+//		}
+//		realm.close();
+//	}
+//}

--- a/app/src/main/java/kesshou/android/daanx/service/MyFirebaseMessagingService.java
+++ b/app/src/main/java/kesshou/android/daanx/service/MyFirebaseMessagingService.java
@@ -5,12 +5,43 @@ import android.util.Log;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import io.realm.Realm;
+import io.realm.RealmResults;
+import kesshou.android.daanx.models.NotiSetting;
+import kesshou.android.daanx.models.Setting;
+import kesshou.android.daanx.util.network.MyCallBack;
+import kesshou.android.daanx.util.network.NetworkingClient;
+import kesshou.android.daanx.util.network.api.holder.Error;
+import kesshou.android.daanx.util.network.api.holder.StatusResponse;
+import retrofit2.Call;
+import retrofit2.Response;
+
 /**
  * Created by yoyoIU on 2016/12/19.
  */
 
 public class MyFirebaseMessagingService extends FirebaseMessagingService {
 	private static final String TAG = "MyFirebaseMsgService";
+
+	// Token updates
+    // This used to be in MyFirebaseInstanceIDService
+    /**
+     * Called if InstanceID token is updated. This may occur if the security of
+     * the previous token had been compromised. Note that this is called when the InstanceID token
+     * is initially generated so this is where you would retrieve the token.
+     */
+    @Override
+    public void onNewToken(String token) {
+        Log.d(TAG, "Refreshed token: " + token);
+
+        // If you want to send messages to this application instance or
+        // manage this apps subscriptions on the server side, send the
+        // Instance ID token to your app server.
+        //sendRegistrationToServer(token);
+        Log.d(TAG, "New token: " + token);
+        saveRegistration(token);
+        ifSendServerOrNot(token);
+    }
 
 	/**
 	 * Called when message is received.
@@ -48,4 +79,45 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 		// message, here is where that should be initiated. See sendNotification method below.
 	}
 	// [END receive_message]
+
+
+    // Token registration server update
+    // Moved from MyFirebaseInstanceIDService
+    private void saveRegistration(String token){
+        Realm realm = Realm.getDefaultInstance();
+        if(realm.where(NotiSetting.class).findAll().size()==0){
+            realm.beginTransaction();
+            NotiSetting notiSetting = realm.createObject(NotiSetting.class);
+            notiSetting.fcm_token = token;
+            notiSetting.is_noti = true;
+            realm.commitTransaction();
+        }else{
+            NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
+            realm.beginTransaction();
+            notiSetting.fcm_token = token;
+            realm.commitTransaction();
+        }
+        realm.close();
+    }
+
+    private void ifSendServerOrNot(String token){
+        Realm realm = Realm.getDefaultInstance();
+        RealmResults<Setting> settings = realm.where(Setting.class).findAll();
+        if(settings.size()!=0&&settings.get(0).logined){
+            NotiSetting notiSetting = realm.where(NotiSetting.class).findFirst();
+            new NetworkingClient(getApplicationContext()).setNoti(token, notiSetting.is_noti, new MyCallBack<StatusResponse>(getApplicationContext()) {
+                @Override
+                public void onSuccess(Response<StatusResponse> response) {
+                    Log.d("fcm_token",response.body().status);
+                }
+
+                @Override
+                public void onErr(Error error, Call<StatusResponse> call) {
+                    call.clone().enqueue(this);
+                }
+            });
+        }
+        realm.close();
+    }
+
 }

--- a/app/src/main/java/kesshou/android/daanx/views/main/InforFragment.java
+++ b/app/src/main/java/kesshou/android/daanx/views/main/InforFragment.java
@@ -185,6 +185,9 @@ public class InforFragment extends Fragment {
 			case "綜高":
 				result = "高";
 				break;
+			case "綜職":
+			    result = "職";
+			    break;
 		}
 		return result;
 	}

--- a/app/src/main/java/kesshou/android/daanx/views/main/MenuFragment.java
+++ b/app/src/main/java/kesshou/android/daanx/views/main/MenuFragment.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.crashlytics.android.Crashlytics;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import java.util.ArrayList;
@@ -179,6 +180,16 @@ public class MenuFragment extends Fragment {
 				}
 			});
 			menus.add(logout);
+
+			// Crashlytics test code
+            // FIXME: Remove before merge
+			Menu crashTest = new Menu(R.drawable.ic_close,BeautifulColor.getRandomColor(),"Force Crashlytics Crash", "", new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    Crashlytics.getInstance().crash();
+                }
+            });
+			menus.add(crashTest);
 
 			RecyclerView recyclerView = (RecyclerView) rootView.findViewById(R.id.menu_list);
 			MenuListAdapter menuListAdapter = new MenuListAdapter(menus,getActivity().getApplicationContext());

--- a/app/src/main/java/kesshou/android/daanx/views/main/NewsFragment.java
+++ b/app/src/main/java/kesshou/android/daanx/views/main/NewsFragment.java
@@ -83,7 +83,7 @@ public class NewsFragment extends Fragment {
 					bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, "School map");
 					bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "fn");
 					((MainActivity)getActivity()).mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle);
-					ChromeTabHelper.openTabs(getActivity(),"http://www.taivs.tp.edu.tw/images/img-building.jpg");
+					ChromeTabHelper.openTabs(getActivity(),"http://docs.google.com/gview?embedded=true&url=www.taivs.tp.edu.tw/tw/doc/daan-buildings.pdf");
 				}
 			});
 			menus.add(map);
@@ -95,7 +95,7 @@ public class NewsFragment extends Fragment {
 					bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, "School map");
 					bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "fn");
 					((MainActivity)getActivity()).mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle);
-					ChromeTabHelper.openTabs(getActivity(),"https://dev.dacsc.club/v1/seatstate");
+					ChromeTabHelper.openTabs(getActivity(),"https://kesshou.dacsc.club/v1/seatstate");
 				}
 			});
 			menus.add(seatState);

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,14 @@ allprojects {
         jcenter()
         mavenLocal()
         maven { url "https://jitpack.io" }
+        maven { url 'https://maven.google.com/' }
         google()
     }
 }
 
 buildscript {
     repositories {
+        maven { url 'https://maven.fabric.io/public' }
         google()
         jcenter()
         mavenLocal()
@@ -18,6 +20,7 @@ buildscript {
         //classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.google.gms:google-services:4.0.1'
+        classpath 'io.fabric.tools:gradle:1.25.4'
         classpath "io.realm:realm-gradle-plugin:5.4.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ allprojects {
         jcenter()
         mavenLocal()
         maven { url "https://jitpack.io" }
-        maven { url "https://maven.google.com" }
         google()
     }
 }
@@ -18,7 +17,7 @@ buildscript {
     dependencies {
         //classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:4.0.1'
         classpath "io.realm:realm-gradle-plugin:5.4.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,17 +4,21 @@ allprojects {
         jcenter()
         mavenLocal()
         maven { url "https://jitpack.io" }
+        maven { url "https://maven.google.com" }
+        google()
     }
 }
 
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        //classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath "io.realm:realm-gradle-plugin:2.1.1"
+        classpath "io.realm:realm-gradle-plugin:5.4.0"
     }
 }


### PR DESCRIPTION
# Updated lib
 * Gradle 2.2.3 -> 3.1.3
 * Realm 2.1.1 -> 5.4.0
 * Google Services 3.0.0 -> 4.0.1

[a3458a264759495f4953dc6a747827a34c3cf5fc] Google mark `FirebaseInstanceIdService` deprecated, 原先的 `onTokenRefresh()` 調整後移動到 `FirebaseMessagingService` `onNewToken(String token)` 
Review後可考慮將MyFirebaseInstanceIDService.java移除

[02c92ab01bd93ce69c9b37ad2db8b8f2c3c267eb] 在MenuFragment.java後面加了個選項可以測試Crashlytics, **Merge前必須移除**

# Notice
Firebase服務基本測試沒有問題，但可能還需要多測試Cloud Messaging的功能
`.../views/main/MenuFragment.java` 最後的Crashlytics選項必須在Merge前移除
Update version name before merge

### Small changes
[47a582a83fa1c9c2e6f6d2342dc0b6d7d6a4d7e8] 加入綜職
[1bb3e3a70a09810d1174cb5e160058693fba3c54] 更新學校地圖&自修室URL

Thank you :)